### PR TITLE
Resolve main.dart 404 in release build

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,8 +15,10 @@ dependencies:
   less_dart: any
   browser: any
   html: any
+  dart_to_js_script_rewriter: '^0.1.0'
 transformers:
   - less_dart:
       include_path: ../lib/components/
   - angular2:
       entry_points: web/main.dart
+  - dart_to_js_script_rewriter


### PR DESCRIPTION
added dart to js script rewriter to resolve main.dart 404 when building release
